### PR TITLE
Fixed reading buffer error

### DIFF
--- a/kafka/io.py
+++ b/kafka/io.py
@@ -38,12 +38,12 @@ class IO(object):
     """ Send a read request to the remote Kafka server. """
 
     # Create a character array to act as the buffer.
-    buf         = array.array('c', ' ' * length)
+    buf         = bytearray(length)
     bytes_left  = length
 
     try:
       while bytes_left > 0:
-        read_length = self.socket.recv_into(buf, bytes_left)
+        read_length = self.socket.recv_into(memoryview(buf)[length-bytes_left:], bytes_left)
         bytes_left -= read_length
 
     except errno.EAGAIN:
@@ -51,7 +51,7 @@ class IO(object):
       raise IOError, "Timeout reading from the socket."
 
     else:
-      return buf.tostring()
+      return str(buf)
 
   def write(self, data):
     """ Write `data` to the remote Kafka server. """

--- a/kafka/io.py
+++ b/kafka/io.py
@@ -39,11 +39,12 @@ class IO(object):
 
     # Create a character array to act as the buffer.
     buf         = array.array('c', ' ' * length)
-    read_length = 0
+    bytes_left  = length
 
     try:
-      while read_length < length:
-        read_length += self.socket.recv_into(buf, length)
+      while bytes_left > 0:
+        read_length = self.socket.recv_into(buf, bytes_left)
+        bytes_left -= read_length
 
     except errno.EAGAIN:
       self.disconnect()


### PR DESCRIPTION
This error was due to the fact that the read length was not changed to only read remaining bytes. Due to the fact that array.array does not accept specifying an offset byte array coupled with a memory view was used instead.
