### PR TITLE
BatchProducer: bug fix and cleanup

### DIFF
--- a/kafka/producer.py
+++ b/kafka/producer.py
@@ -1,3 +1,4 @@
+import atexit
 import contextlib
 import itertools
 import struct
@@ -91,8 +92,10 @@ class BatchProducer(Producer):
     self.event = threading.Event()
     self.lock = threading.Lock()
     self.timer = threading.Thread(target=self._interval_timer)
+    self.timer.daemon = True
     self.connect()
     self.timer.start()
+    atexit.register(self.close)
 
   def _interval_timer(self):
     """Flush the message queue every `batch_interval` seconds."""

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.bootstrap_install_from = None
 
 setuptools.setup(
   name = 'pykafka',
-  version = '0.1.1',
+  version = '0.1.2',
   license = 'MIT',
   long_description = __doc__,
   author = "Dan Sully",


### PR DESCRIPTION
- BatchProducer should run in daemon mode and should die when the main process dies and all messages should be flushed.
