### PR TITLE
Exception was catching error codes instead of an exception class

### DIFF
--- a/kafka/io.py
+++ b/kafka/io.py
@@ -64,10 +64,11 @@ class IO(object):
     try:
       wrote_length = self.__write(data)
 
-    except (errno.ECONNRESET, errno.EPIPE, errno.ECONNABORTED):
+    except IOError, e:
       # Retry once.
-      self.reconnect()
-      wrote_length = self.__write(data)
+      if e.errno in (errno.ECONNRESET, errno.EPIPE, errno.ECONNABORTED):
+        self.reconnect()
+        wrote_length = self.__write(data)
 
     finally:
       return wrote_length


### PR DESCRIPTION
I changed the except clause to catch IOError since catching the int error codes does not work. The same error codes are then checked to initiate a retry and reconnect.
